### PR TITLE
Refactor Login component to add temporary client login functionality

### DIFF
--- a/src/pages/unauthenticated/Login.jsx
+++ b/src/pages/unauthenticated/Login.jsx
@@ -70,6 +70,34 @@ export default function Login() {
     e.preventDefault();
     setLoading(true);
     setErrorMessage("");
+
+    // Temporary implementation for client login
+    if (formData.email === "marvin@mds-innovation.com" && formData.password === "W8!fX2#pL9yQ3@zT5vN6$mRk") {
+      login("dummyToken", {
+        email: "marvin@mds-innovation.com",
+        name: "Marvin",
+        id: "dummyId1",
+        username: "marvin",
+        country: "dummyCountry"
+      });
+      navigate("/welcome", { state: { username: "Marvin" } });
+      setLoading(false);
+      return;
+    }
+
+    if (formData.email === "marykay1993@gmail.com" && formData.password === "maryhasalittlelamb") {
+      login("dummyToken", {
+        email: "marykay1993@gmail.com",
+        name: "Marykay",
+        id: "dummyId2",
+        username: "marykay",
+        country: "dummyCountry"
+      });
+      navigate("/welcome", { state: { username: "Marykay" } });
+      setLoading(false);
+      return;
+    }
+
     try {
       const response = await loginUser(formData.email, formData.password);
       


### PR DESCRIPTION
This pull request introduces a temporary implementation for client login in the `Login` component. The changes include adding hardcoded credentials for two users to facilitate testing and development.

Temporary client login implementation:

* [`src/pages/unauthenticated/Login.jsx`](diffhunk://#diff-be133be462c70180e8fe595f8d7e31bbcbce457aebf5b2f2f26163cf7d85bc2dR73-R100): Added hardcoded credentials for users "marvin@mds-innovation.com" and "marykay1993@gmail.com" to bypass the usual login process and directly navigate to the welcome page.